### PR TITLE
Add GPU-aware MPI support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set( CMAKE_CXX_STANDARD 14 )
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
 set(CMAKE_CXX_FLAGS_Release "${CMAKE_C_FLAGS_Release} -O3")
 ADD_DEFINITIONS(-DROCM=1)
+ADD_DEFINITIONS(-DHPL_COPY_L=1)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/HPL.dat
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/scripts/runHPL_singleNode.sh
@@ -116,7 +117,7 @@ src/comm/HPL_blonM.cpp src/comm/HPL_1ring.cpp src/comm/HPL_2ring.cpp
 src/comm/HPL_1rinM.cpp src/comm/HPL_2rinM.cpp src/comm/HPL_packL.cpp
 src/comm/HPL_sdrv.cpp src/comm/HPL_send.cpp src/pgesv/HPL_pdlaswp00N.cpp
 src/comm/HPL_recv.cpp src/grid/HPL_reduce.cpp src/comm/HPL_binit.cpp
-src/comm/HPL_bwait.cpp
+src/comm/HPL_bwait.cpp src/comm/HPL_copyL.cpp
 src/pgesv/HPL_pdlaswp00T.cpp src/pgesv/HPL_pdlaswp01N.cpp
 src/pgesv/HPL_pdlaswp01T.cpp src/pgesv/HPL_pdupdateNT.cpp
 src/pgesv/HPL_pdupdateTN.cpp src/pgesv/HPL_pdupdateTT.cpp

--- a/HPL.dat
+++ b/HPL.dat
@@ -20,7 +20,7 @@ HPL.out      output file name (if any)
 1            # of recursive panel fact.
 2            RFACTs (0=left, 1=Crout, 2=Right)
 1            # of broadcast
-3            BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM,6=ibcast)
+6            BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM,6=ibcast)
 1            # of lookahead depth
 1            DEPTHs (>=0)
 1            SWAP (0=bin-exch,1=long,2=mix)

--- a/include/backend/hpl_backendHIP.h
+++ b/include/backend/hpl_backendHIP.h
@@ -94,9 +94,9 @@ namespace HIP {
     void stream_wait_event(enum HPL_STREAM, enum HPL_EVENT);
     void device_sync();
 
-    int binit_ibcst(HPL_T_panel*);
-    int bcast_ibcst(HPL_T_panel*, int*);
-    int bwait_ibcst(HPL_T_panel*);
+    void binit_ibcst(HPL_T_panel*, int &);
+    void bcast_ibcst(HPL_T_panel*, int*, int&);
+    void bwait_ibcst(HPL_T_panel*, int &);
 /*
 *  ----------------------------------------------------------------------
 *  - BLAS ---------------------------------------------------------------

--- a/include/backend/hpl_backendHIP.h
+++ b/include/backend/hpl_backendHIP.h
@@ -93,6 +93,10 @@ namespace HIP {
     void stream_synchronize(enum HPL_STREAM);
     void stream_wait_event(enum HPL_STREAM, enum HPL_EVENT);
     void device_sync();
+
+    int binit_ibcst(HPL_T_panel*);
+    int bcast_ibcst(HPL_T_panel*, int*);
+    int bwait_ibcst(HPL_T_panel*);
 /*
 *  ----------------------------------------------------------------------
 *  - BLAS ---------------------------------------------------------------

--- a/include/backend/hpl_backendWrapper.h
+++ b/include/backend/hpl_backendWrapper.h
@@ -56,9 +56,9 @@ void HPL_BE_stream_sync(enum HPL_STREAM, enum HPL_TARGET);
 /*
     Broadcast routine
 */
-void HPL_BE_binit_ibcast(HPL_T_panel*);
-void HPL_BE_bcast_ibcast(HPL_T_panel*, int*);
-int HPL_BE_bwait_ibcast(HPL_T_panel*);
+void HPL_BE_binit_ibcast(HPL_T_panel*, int&, HPL_TARGET);
+void HPL_BE_bcast_ibcast(HPL_T_panel*, int*, int&, HPL_TARGET);
+void HPL_BE_bwait_ibcast(HPL_T_panel*, int&, HPL_TARGET);
 /*
 *  ----------------------------------------------------------------------
 *  - BLAS ---------------------------------------------------------------

--- a/include/backend/hpl_backendWrapper.h
+++ b/include/backend/hpl_backendWrapper.h
@@ -52,6 +52,13 @@ void HPL_BE_stream_synchronize(enum HPL_STREAM, enum HPL_TARGET);
 void HPL_BE_stream_wait_event(enum HPL_STREAM, enum HPL_EVENT, enum HPL_TARGET);
 
 void HPL_BE_stream_sync(enum HPL_STREAM, enum HPL_TARGET);
+
+/*
+    Broadcast routine
+*/
+void HPL_BE_binit_ibcast(HPL_T_panel*);
+void HPL_BE_bcast_ibcast(HPL_T_panel*, int*);
+int HPL_BE_bwait_ibcast(HPL_T_panel*);
 /*
 *  ----------------------------------------------------------------------
 *  - BLAS ---------------------------------------------------------------

--- a/include/hpl_comm.h
+++ b/include/hpl_comm.h
@@ -64,7 +64,8 @@ typedef enum
    HPL_2RING         = 403,                      /* Increasing 2-ring */
    HPL_2RING_M       = 404,           /* Increasing 2-ring (modified) */
    HPL_BLONG         = 405,                         /* long broadcast */
-   HPL_BLONG_M       = 406               /* long broadcast (modified) */
+   HPL_BLONG_M       = 406,               /* long broadcast (modified) */
+   HPL_IBCAST       = 407               /* default bcast in MPI */
 } HPL_T_TOP;
 /*
  * ---------------------------------------------------------------------

--- a/scripts/runHPL_singleNode.sh
+++ b/scripts/runHPL_singleNode.sh
@@ -9,5 +9,5 @@ export OMP_NUM_THREADS=${num_cpu_cores}
 export LD_LIBRARY_PATH=openblas:$LD_LIBRARY_PATH
 
 # ./xhpl
-HSA_ENABLE_SDMA=1 ${MPI_DIR}/mpirun --allow-run-as-root -np ${num_process} --map-by node:PE=${num_cpu_cores} --bind-to core:overload-allowed --report-bindings ./xhplhip
+HSA_ENABLE_SDMA=1 ${MPI_DIR}/mpirun  -mca btl '^openib' --mca pml ucx -x UCX_RNDV_PIPELINE_SEND_THRESH=256k -x UCX_RNDV_FRAG_SIZE=rocm:4m --allow-run-as-root -np ${num_process} --map-by node:PE=${num_cpu_cores} --bind-to core:overload-allowed --report-bindings ./xhplhip
 grep --color "e+" HPL.out

--- a/src/comm/HPL_bcast.cpp
+++ b/src/comm/HPL_bcast.cpp
@@ -108,7 +108,7 @@ int HPL_bcast
       case HPL_2RING   : ierr = HPL_bcast_2ring( PANEL, IFLAG ); break;
       case HPL_BLONG_M : ierr = HPL_bcast_blonM( PANEL, IFLAG ); break;
       case HPL_BLONG   : ierr = HPL_bcast_blong( PANEL, IFLAG ); break;
-      case HPL_IBCAST  : ierr = HPL_BE_bcast_ibcast( PANEL, IFLAG ); break;
+      case HPL_IBCAST  : HPL_BE_bcast_ibcast( PANEL, IFLAG, ierr, T_HIP); break;
       default          : ierr = HPL_SUCCESS;
    }
  

--- a/src/comm/HPL_bcast.cpp
+++ b/src/comm/HPL_bcast.cpp
@@ -108,6 +108,7 @@ int HPL_bcast
       case HPL_2RING   : ierr = HPL_bcast_2ring( PANEL, IFLAG ); break;
       case HPL_BLONG_M : ierr = HPL_bcast_blonM( PANEL, IFLAG ); break;
       case HPL_BLONG   : ierr = HPL_bcast_blong( PANEL, IFLAG ); break;
+      case HPL_IBCAST  : ierr = HPL_BE_bcast_ibcast( PANEL, IFLAG ); break;
       default          : ierr = HPL_SUCCESS;
    }
  

--- a/src/comm/HPL_binit.cpp
+++ b/src/comm/HPL_binit.cpp
@@ -98,7 +98,7 @@ int HPL_binit
       case HPL_2RING   : ierr = HPL_binit_2ring( PANEL ); break;
       case HPL_BLONG_M : ierr = HPL_binit_blonM( PANEL ); break;
       case HPL_BLONG   : ierr = HPL_binit_blong( PANEL ); break;
-      case HPL_IBCAST  : ierr = HPL_BE_binit_ibcast( PANEL ); break;
+      case HPL_IBCAST  : HPL_BE_binit_ibcast( PANEL, ierr, T_HIP ); break;
       default          : ierr = HPL_SUCCESS;
    }
  

--- a/src/comm/HPL_binit.cpp
+++ b/src/comm/HPL_binit.cpp
@@ -98,6 +98,7 @@ int HPL_binit
       case HPL_2RING   : ierr = HPL_binit_2ring( PANEL ); break;
       case HPL_BLONG_M : ierr = HPL_binit_blonM( PANEL ); break;
       case HPL_BLONG   : ierr = HPL_binit_blong( PANEL ); break;
+      case HPL_IBCAST  : ierr = HPL_BE_binit_ibcast( PANEL ); break;
       default          : ierr = HPL_SUCCESS;
    }
  

--- a/src/comm/HPL_bwait.cpp
+++ b/src/comm/HPL_bwait.cpp
@@ -99,7 +99,7 @@ int HPL_bwait
       case HPL_2RING   : ierr = HPL_bwait_2ring( PANEL ); break;
       case HPL_BLONG_M : ierr = HPL_bwait_blonM( PANEL ); break;
       case HPL_BLONG   : ierr = HPL_bwait_blong( PANEL ); break;
-      case HPL_IBCAST  : ierr = HPL_BE_bwait_ibcast( PANEL ); break;
+      case HPL_IBCAST  : HPL_BE_bwait_ibcast( PANEL, ierr, T_HIP ); break;
       default          : ierr = HPL_SUCCESS;
    }
  

--- a/src/comm/HPL_bwait.cpp
+++ b/src/comm/HPL_bwait.cpp
@@ -99,6 +99,7 @@ int HPL_bwait
       case HPL_2RING   : ierr = HPL_bwait_2ring( PANEL ); break;
       case HPL_BLONG_M : ierr = HPL_bwait_blonM( PANEL ); break;
       case HPL_BLONG   : ierr = HPL_bwait_blong( PANEL ); break;
+      case HPL_IBCAST  : ierr = HPL_BE_bwait_ibcast( PANEL ); break;
       default          : ierr = HPL_SUCCESS;
    }
  

--- a/src/comm/HPL_packL.cpp
+++ b/src/comm/HPL_packL.cpp
@@ -117,7 +117,7 @@ int HPL_packL
  * Panel + L1 + DPIV  have been copied into a contiguous buffer - Create
  * and commit a contiguous data type
  */
-   PANEL->buffers[IBUF] = (void *)(PANEL->L2 + INDEX);
+   PANEL->buffers[IBUF] = (void ***)(PANEL->L2 + INDEX);
    PANEL->counts [IBUF] = 1;
 
    ierr =      MPI_Type_contiguous( LEN, MPI_DOUBLE, &PANEL->dtypes[IBUF] );

--- a/src/pfact/HPL_pdfact.cpp
+++ b/src/pfact/HPL_pdfact.cpp
@@ -134,7 +134,7 @@ void HPL_pdfact
    if( vptr ) HPL_BE_free((void**)&vptr, T_TEMPO);
    //if( vptr ) free( vptr );
 
-   PANEL->A   = Mptr( PANEL->A, 0, jb, PANEL->lda );
+   // PANEL->A   = Mptr( PANEL->A, 0, jb, PANEL->lda );
 #ifdef ROCM
    PANEL->dA   = Mptr( PANEL->dA, 0, jb, PANEL->lda );
 #endif

--- a/src/pgesv/HPL_pdgesvK2.cpp
+++ b/src/pgesv/HPL_pdgesvK2.cpp
@@ -157,15 +157,16 @@ void HPL_pdgesvK2
       HPL_BE_event_synchronize(HPL_PANEL_COPY, T_HIP);
 
       HPL_pdfact(         panel[k] );
+
+      HPL_BE_panel_send_to_device( panel[k], T_HIP );
+      HPL_BE_event_record(HPL_PANEL_COPY, T_HIP);
+      HPL_BE_event_synchronize(HPL_PANEL_COPY, T_HIP);
+
       (void) HPL_binit(   panel[k] );
       do
       { (void) HPL_bcast( panel[k], &test ); }
       while( test != HPL_SUCCESS );
       (void) HPL_bwait(   panel[k] );
-
-      HPL_BE_panel_send_to_device( panel[k], T_HIP );
-      HPL_BE_event_record(HPL_PANEL_COPY, T_HIP);
-      HPL_BE_event_synchronize(HPL_PANEL_COPY, T_HIP);
 
 /*
  * Partial update of the depth-k-1 panels in front of me
@@ -234,16 +235,17 @@ void HPL_pdgesvK2
          HPL_BE_event_synchronize(HPL_PANEL_COPY, T_HIP);
 
          HPL_pdfact(       panel[depth] );    /* factor current panel */
-         (void) HPL_binit(   panel[depth] );
 
+         HPL_BE_panel_send_to_device(panel[depth], T_HIP);  
+         HPL_BE_event_record(HPL_PANEL_COPY, T_HIP);
+         HPL_BE_event_synchronize(HPL_PANEL_COPY, T_HIP);
+
+         (void) HPL_binit(   panel[depth] );
          do
          { (void) HPL_bcast( panel[depth], &test ); }
          while( test != HPL_SUCCESS );
          (void) HPL_bwait(   panel[depth] );
 
-         HPL_BE_panel_send_to_device(panel[depth], T_HIP);  
-         HPL_BE_event_record(HPL_PANEL_COPY, T_HIP);
-         HPL_BE_event_synchronize(HPL_PANEL_COPY, T_HIP);
       }
       else { 
          nn = 0; 
@@ -258,9 +260,6 @@ void HPL_pdgesvK2
          while( test != HPL_SUCCESS );
          (void) HPL_bwait( panel[depth] );
 
-         HPL_BE_panel_send_to_device( panel[depth], T_HIP);
-         HPL_BE_event_record(HPL_PANEL_UPDATE, T_HIP);
-         HPL_BE_event_synchronize(HPL_PANEL_UPDATE, T_HIP);
       }
 
      HPL_BE_device_sync(T_HIP);

--- a/testing/backend/HPL_backendHIP.cpp
+++ b/testing/backend/HPL_backendHIP.cpp
@@ -956,9 +956,9 @@ void HIP::pdlaswp(HPL_T_panel *PANEL, const int NN){
                                       nn, jb, Aptr, lda, ipiv);
 }
 
-int HIP::binit_ibcst(HPL_T_panel* PANEL) {
+void HIP::binit_ibcst(HPL_T_panel* PANEL, int &result) {
 
-    return (HPL_SUCCESS);
+    result = HPL_SUCCESS;
 }
 
 #define _M_BUFF (void*)(PANEL->dL2)
@@ -968,17 +968,19 @@ int HIP::binit_ibcst(HPL_T_panel* PANEL) {
 static MPI_Request request  = MPI_REQUEST_NULL;
 static MPI_Request request2 = MPI_REQUEST_NULL;
 
-int HIP::bcast_ibcst(HPL_T_panel* PANEL, int* IFLAG) {
+void HIP::bcast_ibcst(HPL_T_panel* PANEL, int* IFLAG, int &result) {
   MPI_Comm comm;
   int      ierr, ierr2, go, next, msgid, prev, rank, root, size;
 
   if(PANEL == NULL) {
     *IFLAG = HPL_SUCCESS;
-    return (HPL_SUCCESS);
+    result = HPL_SUCCESS;
+    return;
   }
   if((size = PANEL->grid->npcol) <= 1) {
     *IFLAG = HPL_SUCCESS;
-    return (HPL_SUCCESS);
+    result = HPL_SUCCESS;
+    return;
   }
 
   rank  = PANEL->grid->mycol;
@@ -995,19 +997,19 @@ int HIP::bcast_ibcst(HPL_T_panel* PANEL, int* IFLAG) {
   *IFLAG = (ierr == MPI_SUCCESS ? HPL_SUCCESS : HPL_FAILURE);
   *IFLAG = (ierr2 == MPI_SUCCESS ? *IFLAG : HPL_FAILURE);
 
-  return (*IFLAG);
+    result = *IFLAG;
 }
 
-int HIP::bwait_ibcst(HPL_T_panel* PANEL) {
+void HIP::bwait_ibcst(HPL_T_panel* PANEL, int &result) {
   int ierr1, ierr2;
 
-  if(PANEL == NULL) { return (HPL_SUCCESS); }
-  if(PANEL->grid->npcol <= 1) { return (HPL_SUCCESS); }
+  if(PANEL == NULL) { result = HPL_SUCCESS; return; }
+  if(PANEL->grid->npcol <= 1) { result = HPL_SUCCESS; return; }
 
   ierr1 = MPI_Wait(&request, MPI_STATUS_IGNORE);
   ierr2 = MPI_Wait(&request2, MPI_STATUS_IGNORE);
 
-  return ((ierr1 == MPI_SUCCESS
+  result = (ierr1 == MPI_SUCCESS
                ? (ierr2 == MPI_SUCCESS ? HPL_SUCCESS : HPL_FAILURE)
-               : HPL_FAILURE));
+               : HPL_FAILURE);
 }

--- a/testing/backend/HPL_backendWrapper.cpp
+++ b/testing/backend/HPL_backendWrapper.cpp
@@ -239,42 +239,42 @@ extern "C" {
    /*
    * Broadcast routine
    */
-   void HPL_BE_binit_ibcast(HPL_T_panel* PANEL)
+   void HPL_BE_binit_ibcast(HPL_T_panel* PANEL, int &result, HPL_TARGET TR)
    {
       switch(TR) {
          case T_CPU :
             DO_NOTHING();
             break;
          case T_HIP:
-            HPL::dispatch(HIP::binit_ibcst, PANEL);
+            HPL::dispatch(HIP::binit_ibcst, PANEL, result);
             break;
          default:
             DO_NOTHING();
       }
    }
 
-   void HPL_BE_bcast_ibcast(HPL_T_panel* PANEL, int* FLAG)
+   void HPL_BE_bcast_ibcast(HPL_T_panel* PANEL, int* FLAG, int &result, HPL_TARGET TR)
    {
       switch(TR) {
          case T_CPU :
             DO_NOTHING();
             break;
          case T_HIP:
-            HPL::dispatch(HIP::bcast_ibcst, PANEL, FLAG);
+            HPL::dispatch(HIP::bcast_ibcst, PANEL, FLAG, result);
             break;
          default:
             DO_NOTHING();
       }
    }
 
-   int HPL_BE_bwait_ibcast(HPL_T_panel* PANEL)
+   void HPL_BE_bwait_ibcast(HPL_T_panel* PANEL, int &result, HPL_TARGET TR)
    {
       switch(TR) {
          case T_CPU :
             DO_NOTHING();
             break;
          case T_HIP:
-            HPL::dispatch(HIP::bwait_ibcst, PANEL);
+            HPL::dispatch(HIP::bwait_ibcst, PANEL, result);
             break;
          default:
             DO_NOTHING();

--- a/testing/backend/HPL_backendWrapper.cpp
+++ b/testing/backend/HPL_backendWrapper.cpp
@@ -236,6 +236,51 @@ extern "C" {
       }
    }
 
+   /*
+   * Broadcast routine
+   */
+   void HPL_BE_binit_ibcast(HPL_T_panel* PANEL)
+   {
+      switch(TR) {
+         case T_CPU :
+            DO_NOTHING();
+            break;
+         case T_HIP:
+            HPL::dispatch(HIP::binit_ibcst, PANEL);
+            break;
+         default:
+            DO_NOTHING();
+      }
+   }
+
+   void HPL_BE_bcast_ibcast(HPL_T_panel* PANEL, int* FLAG)
+   {
+      switch(TR) {
+         case T_CPU :
+            DO_NOTHING();
+            break;
+         case T_HIP:
+            HPL::dispatch(HIP::bcast_ibcst, PANEL, FLAG);
+            break;
+         default:
+            DO_NOTHING();
+      }
+   }
+
+   int HPL_BE_bwait_ibcast(HPL_T_panel* PANEL)
+   {
+      switch(TR) {
+         case T_CPU :
+            DO_NOTHING();
+            break;
+         case T_HIP:
+            HPL::dispatch(HIP::bwait_ibcst, PANEL);
+            break;
+         default:
+            DO_NOTHING();
+      }
+   }
+
 /*
 *  ----------------------------------------------------------------------
 *  - BLAS ---------------------------------------------------------------

--- a/testing/ptest/HPL_pdinfo.cpp
+++ b/testing/ptest/HPL_pdinfo.cpp
@@ -362,12 +362,22 @@ void HPL_pdinfo
       for( i = 0; i < *NBS; i++ )
       {
          (void) sscanf( lineptr, "%s", num ); lineptr += strlen( num ) + 1;
+#ifdef ROCM
+         NB[ i ] = atoi( num );
+         if( NB[ i ] < 1 || NB[ i ] > 512)
+         {
+            HPL_pwarn( stderr, __LINE__, "HPL_pdinfo", 
+                       "Value of NB less than 1 or greater than 512" );
+            error = 1; goto label_error;
+         }
+#else
          if( ( NB[ i ] = atoi( num ) ) < 1 )
          {
             HPL_pwarn( stderr, __LINE__, "HPL_pdinfo", 
                        "Value of NB less than 1" );
             error = 1; goto label_error;
          }
+#endif
       }
 /*
  * Process grids, mapping, (>=1) (P, Q)
@@ -390,12 +400,21 @@ void HPL_pdinfo
       for( i = 0; i < *NPQS; i++ )
       {
          (void) sscanf( lineptr, "%s", num ); lineptr += strlen( num ) + 1;
+#ifdef ROCM
+         if( ( P[ i ] = atoi( num ) ) != 1 )
+         {
+            HPL_pwarn( stderr, __LINE__, "HPL_pdinfo",
+                       "Value of P is not 1" );
+            error = 1; goto label_error;
+         }
+#elif
          if( ( P[ i ] = atoi( num ) ) < 1 )
          {
             HPL_pwarn( stderr, __LINE__, "HPL_pdinfo",
                        "Value of P less than 1" );
             error = 1; goto label_error;
          }
+#endif
       }
       (void) fgets( line, HPL_LINE_MAX - 2, infp ); lineptr = line;
       for( i = 0; i < *NPQS; i++ )

--- a/testing/ptest/HPL_pdinfo.cpp
+++ b/testing/ptest/HPL_pdinfo.cpp
@@ -538,6 +538,7 @@ void HPL_pdinfo
          else if( j == 3 ) TP[ i ] = HPL_2RING_M;
          else if( j == 4 ) TP[ i ] = HPL_BLONG;
          else if( j == 5 ) TP[ i ] = HPL_BLONG_M;
+         else if( j == 6 ) TP[ i ] = HPL_IBCAST;
          else              TP[ i ] = HPL_1RING_M;
       }
 /*
@@ -702,6 +703,7 @@ label_error:
          else if( TP[i] == HPL_2RING_M ) iwork[j] = 3;
          else if( TP[i] == HPL_BLONG   ) iwork[j] = 4;
          else if( TP[i] == HPL_BLONG_M ) iwork[j] = 5;
+         else if( TP[i] == HPL_IBCAST )  iwork[j] = 6;
          j++;
       }
       for( i = 0; i < *NDHS; i++ ) { iwork[j] = DH[i]; j++; }
@@ -745,6 +747,7 @@ label_error:
          else if( iwork[j] == 3 ) TP[i] = HPL_2RING_M;
          else if( iwork[j] == 4 ) TP[i] = HPL_BLONG;
          else if( iwork[j] == 5 ) TP[i] = HPL_BLONG_M;
+         else if( iwork[j] == 6 ) TP[i] = HPL_IBCAST;
          j++;
       }
       for( i = 0; i < *NDHS; i++ ) { DH[i] = iwork[j]; j++; }
@@ -1008,6 +1011,8 @@ label_error:
             HPL_fprintf( TEST->outfp,       "   Blong " );
          else if( TP[i] == HPL_BLONG_M )
             HPL_fprintf( TEST->outfp,       "  BlongM " );
+         else if( TP[i] == HPL_IBCAST )
+            HPL_fprintf( TEST->outfp,       "  IBCAST " );
       }
       if( *NTPS > 8 )
       {
@@ -1026,6 +1031,8 @@ label_error:
                HPL_fprintf( TEST->outfp,       "   Blong " );
             else if( TP[i] == HPL_BLONG_M )
                HPL_fprintf( TEST->outfp,       "  BlongM " );
+            else if( TP[i] == HPL_IBCAST )
+               HPL_fprintf( TEST->outfp,       "  IBCAST " );
          }
          if( *NTPS > 16 )
          {
@@ -1044,6 +1051,8 @@ label_error:
                   HPL_fprintf( TEST->outfp,       "   Blong " );
                else if( TP[i] == HPL_BLONG_M )
                   HPL_fprintf( TEST->outfp,       "  BlongM " );
+               else if( TP[i] == HPL_IBCAST )
+                  HPL_fprintf( TEST->outfp,       "  IBCAST " );
             }
          }
       }

--- a/testing/ptest/HPL_pdtest.cpp
+++ b/testing/ptest/HPL_pdtest.cpp
@@ -271,6 +271,7 @@ void HPL_pdtest
       else if( ALGO->btopo == HPL_2RING   ) ctop = '2';
       else if( ALGO->btopo == HPL_2RING_M ) ctop = '3';
       else if( ALGO->btopo == HPL_BLONG   ) ctop = '4';
+      else if( ALGO->btopo == HPL_IBCAST  ) ctop = '6';
       else /* if( ALGO->btopo == HPL_BLONG_M ) */ ctop = '5';
 
       if( wtime[0] > HPL_rzero ) {


### PR DESCRIPTION
We added the ibcast API to achieve the communication without CPU involvement. Besides L2 in the panel column, the row swapping information ipiv should be broadcasted to other devices. This implementation can reduce the host-to-device memory time for the non-root processes.